### PR TITLE
Update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "babel-preset-stage-0": "^6.5.0"
   },
   "peerDependencies": {
-    "leaflet": "^0.7.0",
+    "leaflet": "^1.0.0",
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
-    "react-leaflet": "^0.11.5"
+    "react-leaflet": "^1.0.0"
   }
 }


### PR DESCRIPTION
I had an issue with the peer dependencies where and older version of leaflet would be installed on top of my applications leaflet dependency causing a mismatch between the marker file div-icon loaded and the leaflet version.

* Parent project uses leaflet 1.x.x
* react-leaflet-div-icon specifies peer dependency of 0.x.x
* when dependencies are installed, leaflet 1.x.x will be installed in root `node_modules` but react-leaflet-div-icon will also get leaflet 0.x.x in it's dependencies
* when react-leaflet-div-icon looks for the `marker` module in leaflet, it first looks its local node_modules for leaflet, which it finds and then I get an error because of module mismatch

I've updated the peer dependencies to specify the 1.x.x versions which I think should be fine because it looks like you've included updates recently to support react-leaflet's newer api and therefore the module is probably not compatible with older versions of leaflet/react-leaflet anyway