### PR TITLE
Note: React.PropTypes is deprecated as of React v15.5. Please use the…

### DIFF
--- a/div-icon.js
+++ b/div-icon.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes, Children} from 'react';
+import React, {Component, Children} from 'react';
+import PropTypes from 'prop-types';
 import {render} from 'react-dom';
 import {DivIcon, marker} from 'leaflet';
 import {MapLayer} from 'react-leaflet';
@@ -100,4 +101,3 @@ export default class Divicon extends MapLayer {
   }
 
 }
-

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactDom = require('react-dom');
 
 var _leaflet = require('leaflet');
@@ -57,7 +61,7 @@ function createContextProvider(context) {
 
   ContextProvider.childContextTypes = {};
   Object.keys(context).forEach(function (key) {
-    ContextProvider.childContextTypes[key] = _react.PropTypes.any;
+    ContextProvider.childContextTypes[key] = _propTypes2.default.any;
   });
   return ContextProvider;
 }
@@ -160,11 +164,11 @@ var Divicon = function (_MapLayer) {
 }(_reactLeaflet.MapLayer);
 
 Divicon.propTypes = {
-  opacity: _react.PropTypes.number,
-  zIndexOffset: _react.PropTypes.number
+  opacity: _propTypes2.default.number,
+  zIndexOffset: _propTypes2.default.number
 };
 Divicon.childContextTypes = {
-  popupContainer: _react.PropTypes.object
+  popupContainer: _propTypes2.default.object
 };
 exports.default = Divicon;
 

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "react": "^0.14.0 || ^15.0.0",
     "react-dom": "^0.14.0 || ^15.0.0",
     "react-leaflet": "^0.11.5"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
https://facebook.github.io/react/docs/typechecking-with-proptypes.html

Note: React.PropTypes is deprecated as of React v15.5. Please use the prop-types library instead.