### PR TITLE
Add prop-types to support React 16 RC

### DIFF
--- a/div-icon.js
+++ b/div-icon.js
@@ -1,7 +1,8 @@
-import React, {Component, PropTypes, Children} from 'react';
+import React, {Component, Children} from 'react';
 import {render} from 'react-dom';
 import {DivIcon, marker} from 'leaflet';
 import {MapLayer} from 'react-leaflet';
+import PropTypes from 'prop-types';
 
 function createContextProvider(context) {
   class ContextProvider extends Component {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,10 @@ var _leaflet = require('leaflet');
 
 var _reactLeaflet = require('react-leaflet');
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
@@ -57,7 +61,7 @@ function createContextProvider(context) {
 
   ContextProvider.childContextTypes = {};
   Object.keys(context).forEach(function (key) {
-    ContextProvider.childContextTypes[key] = _react.PropTypes.any;
+    ContextProvider.childContextTypes[key] = _propTypes2.default.any;
   });
   return ContextProvider;
 }
@@ -160,11 +164,11 @@ var Divicon = function (_MapLayer) {
 }(_reactLeaflet.MapLayer);
 
 Divicon.propTypes = {
-  opacity: _react.PropTypes.number,
-  zIndexOffset: _react.PropTypes.number
+  opacity: _propTypes2.default.number,
+  zIndexOffset: _propTypes2.default.number
 };
 Divicon.childContextTypes = {
-  popupContainer: _react.PropTypes.object
+  popupContainer: _propTypes2.default.object
 };
 exports.default = Divicon;
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,11 @@
   },
   "peerDependencies": {
     "leaflet": "^0.7.0",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
     "react-leaflet": "^0.11.5"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Since React 16 removes `React.PropTypes`, react-leaflet-div-icon breaks.

This PR adds the prop-types package and allows react & react-dom 16 RC in peer-dependencies.