### PR TITLE
Add IE 10 Support

### DIFF
--- a/div-icon.js
+++ b/div-icon.js
@@ -28,6 +28,8 @@ export default class Divicon extends MapLayer {
     zIndexOffset: PropTypes.number,
   };
 
+  static contextTypes = MapLayer.contextTypes;
+
   static childContextTypes = {
     popupContainer: PropTypes.object,
   };

--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ Divicon.propTypes = {
   opacity: _propTypes2.default.number,
   zIndexOffset: _propTypes2.default.number
 };
+Divicon.contextTypes = _reactLeaflet.MapLayer.contextTypes;
 Divicon.childContextTypes = {
   popupContainer: _propTypes2.default.object
 };


### PR DESCRIPTION
In IE10, I get the following error:

```
Unable to get property 'addLayer' of undefined or null reference 
```

Using the fix found here fixes the issue: PaulLeCam/react-leaflet#235