### PR TITLE
Fixed issue with redundant mounting/unmounting + better position check

### DIFF
--- a/div-icon.js
+++ b/div-icon.js
@@ -72,6 +72,7 @@ export default class Divicon extends MapLayer {
 
   componentDidMount() {
     super.componentDidMount();
+    this.ContextProvider = createContextProvider({...this.context, ...this.getChildContext()});
     this.renderComponent();
   }
 
@@ -81,12 +82,11 @@ export default class Divicon extends MapLayer {
   }
 
   renderComponent = () => {
-    const ContextProvider = createContextProvider({...this.context, ...this.getChildContext()});
     const container = this.leafletElement._icon;
     const component = (
-      <ContextProvider>
+      <this.ContextProvider>
         {this.props.children}
-      </ContextProvider>
+      </this.ContextProvider>
     );
     if (container) {
       render(

--- a/div-icon.js
+++ b/div-icon.js
@@ -46,7 +46,9 @@ export default class Divicon extends MapLayer {
   }
 
   updateLeafletElement(fromProps, toProps) {
-    if (toProps.position !== fromProps.position) {
+    // Even if we don't get a legnth of 2, this will work as the array will return undefined
+    if (toProps.position[0] !== fromProps.position[0] ||
+        toProps.position[1] !== fromProps.position[1] || ) {
       this.leafletElement.setLatLng(toProps.position);
     }
     if (toProps.zIndexOffset !== fromProps.zIndexOffset) {

--- a/index.js
+++ b/index.js
@@ -70,7 +70,8 @@ var Divicon = function (_MapLayer) {
   _inherits(Divicon, _MapLayer);
 
   function Divicon() {
-    var _ref;
+    var _ref,
+        _this3 = this;
 
     var _temp, _this2, _ret;
 
@@ -81,10 +82,9 @@ var Divicon = function (_MapLayer) {
     }
 
     return _ret = (_temp = (_this2 = _possibleConstructorReturn(this, (_ref = Divicon.__proto__ || Object.getPrototypeOf(Divicon)).call.apply(_ref, [this].concat(args))), _this2), _this2.renderComponent = function () {
-      var ContextProvider = createContextProvider(_extends({}, _this2.context, _this2.getChildContext()));
       var container = _this2.leafletElement._icon;
       var component = _react2.default.createElement(
-        ContextProvider,
+        _this3.ContextProvider,
         null,
         _this2.props.children
       );
@@ -145,6 +145,7 @@ var Divicon = function (_MapLayer) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       _get(Divicon.prototype.__proto__ || Object.getPrototypeOf(Divicon.prototype), 'componentDidMount', this).call(this);
+      this.ContextProvider = createContextProvider(_extends({}, this.context, this.getChildContext()));
       this.renderComponent();
     }
   }, {


### PR DESCRIPTION
Hey,

Since the ContextProvider component was created in the renderComponent function, it caused react to mount and unmount the component on every render, since renderComponent created a new ContextProvider class every time. We had a marker with an image in it, and we could see the image reload on every render. If you put a componentDidMount in your inner component you can see it being raised on every render.
We have moved the creating of the ContextProvider to the componentDidMount, as there is no real reason to create it every time, specifically since context is added statically and doesn't change in runtime. 

We also we have changed the comparison of the position, since if you use the component like:
```
<DivIcon position={[this.props.lat, this.props.lng]}
```
It will cause the setLatLng function to be called even if nothing changed, since the comparison was done by array reference.