### PR TITLE
react-leaflet v2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ import DivIcon from 'react-leaflet-div-icon';
 export default class UserLocationExample extends Component {
   constructor() {
     super();
+    this.mapRef = React.createRef()
     this.state = {
       hasLocation: false,
       latlng: {
@@ -30,11 +31,11 @@ export default class UserLocationExample extends Component {
     };
   }
 
-  handleClick() {
-    this.refs.map.leafletElement.locate();
+  handleClick = () => {
+    this.mapRef.current.leafletElement.locate();
   }
 
-  handleLocationFound(e) {
+  handleLocationFound = (e) => {
     this.setState({
       hasLocation: true,
       latlng: e.latlng,
@@ -57,9 +58,9 @@ export default class UserLocationExample extends Component {
       <Map
         center={this.state.latlng}
         length={4}
-        onClick={::this.handleClick}
-        onLocationfound={::this.handleLocationFound}
-        ref='map'
+        onClick={() => this.handleClick()}
+        onLocationfound={(e) => this.handleLocationFound(e)}
+        ref={this.mapRef}
         zoom={13}>
         <TileLayer
           attribution='&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'

--- a/div-icon.js
+++ b/div-icon.js
@@ -1,41 +1,13 @@
 import React, {Component} from 'react';
-import {render} from 'react-dom';
+import ReactDOM, {render} from 'react-dom';
 import {DivIcon, marker} from 'leaflet';
 import {MapLayer, withLeaflet} from 'react-leaflet';
 import PropTypes from 'prop-types';
-
-function createContextProvider(context) {
-  class ContextProvider extends Component {
-    getChildContext() {
-      return context;
-    }
-
-    render() {
-      return this.props.children;
-    }
-  }
-
-  ContextProvider.childContextTypes = {};
-  Object.keys(context).forEach(key => {
-    ContextProvider.childContextTypes[key] = PropTypes.any;
-  });
-  return ContextProvider;
-}
 
 export class Divicon extends MapLayer {
   static propTypes = {
     opacity: PropTypes.number,
     zIndexOffset: PropTypes.number,
-  }
-
-  static childContextTypes = {
-    popupContainer: PropTypes.object,
-  }
-
-  getChildContext() {
-    return {
-      popupContainer: this.leafletElement,
-    }
   }
 
   // See https://github.com/PaulLeCam/react-leaflet/issues/275
@@ -65,35 +37,19 @@ export class Divicon extends MapLayer {
     }
   }
 
-  componentDidMount() {
-    super.componentDidMount();
-    this.renderComponent();
-  }
-
   componentDidUpdate(fromProps) {
-    this.renderComponent();
     this.updateLeafletElement(fromProps, this.props);
   }
 
-  renderComponent = () => {
-    const ContextProvider = createContextProvider({...this.context, ...this.getChildContext()});
-    const container = this.leafletElement._icon;
-    const component = (
-      <ContextProvider>
-        {this.props.children}
-      </ContextProvider>
-    );
-    if (container) {
-      render(
-        component,
-        container
-      );
-    }
-  }
-
   render() {
-    return null;
+    const container = this.leafletElement._icon;
+
+    if (container) {
+      return ReactDOM.createPortal(this.props.children, container);
+    } else {
+      return null;
+    }
   }
 }
 
-export default withLeaflet(Divicon)
+export default withLeaflet(Divicon);

--- a/div-icon.js
+++ b/div-icon.js
@@ -1,7 +1,7 @@
-import React, {Component} from 'react';
-import ReactDOM, {render} from 'react-dom';
-import {DivIcon, marker} from 'leaflet';
-import {MapLayer, withLeaflet} from 'react-leaflet';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { DivIcon, marker } from 'leaflet';
+import { MapLayer, withLeaflet, LeafletProvider } from 'react-leaflet';
 import PropTypes from 'prop-types';
 
 export class Divicon extends MapLayer {
@@ -10,11 +10,18 @@ export class Divicon extends MapLayer {
     zIndexOffset: PropTypes.number,
   }
 
+  constructor(props){
+    super(props)
+    super.componentDidMount();
+  }
+
   // See https://github.com/PaulLeCam/react-leaflet/issues/275
   createLeafletElement(newProps) {
-    const {map: _map, layerContainer: _lc, position, ...props} = newProps;
+    const { map: _map, layerContainer: _lc, position, ...props } = newProps;
     this.icon = new DivIcon(props);
-    return marker(position, {icon: this.icon, ...props});
+    const m = marker(position, { icon: this.icon, ...props });
+    this.contextValue = { ...props.leaflet, popupContainer: m }
+    return m
   }
 
   updateLeafletElement(fromProps, toProps) {
@@ -43,13 +50,15 @@ export class Divicon extends MapLayer {
 
   render() {
     const container = this.leafletElement._icon;
-
     if (container) {
-      return ReactDOM.createPortal(this.props.children, container);
-    } else {
-      return null;
+      return ReactDOM.createPortal(<LeafletProvider value={this.contextValue}>
+        {this.props.children}
+      </LeafletProvider>, container)
+    }
+    else {
+      return null
     }
   }
 }
 
-export default withLeaflet(Divicon);
+export default withLeaflet(Divicon)

--- a/div-icon.js
+++ b/div-icon.js
@@ -22,15 +22,15 @@ function createContextProvider(context) {
   return ContextProvider;
 }
 
-class Divicon extends MapLayer {
+export class Divicon extends MapLayer {
   static propTypes = {
     opacity: PropTypes.number,
     zIndexOffset: PropTypes.number,
-  };
+  }
 
   static childContextTypes = {
     popupContainer: PropTypes.object,
-  };
+  }
 
   getChildContext() {
     return {

--- a/div-icon.js
+++ b/div-icon.js
@@ -1,7 +1,7 @@
-import React, {Component, Children} from 'react';
+import React, {Component} from 'react';
 import {render} from 'react-dom';
 import {DivIcon, marker} from 'leaflet';
-import {MapLayer} from 'react-leaflet';
+import {MapLayer, withLeaflet} from 'react-leaflet';
 import PropTypes from 'prop-types';
 
 function createContextProvider(context) {
@@ -22,7 +22,7 @@ function createContextProvider(context) {
   return ContextProvider;
 }
 
-export default class Divicon extends MapLayer {
+class Divicon extends MapLayer {
   static propTypes = {
     opacity: PropTypes.number,
     zIndexOffset: PropTypes.number,
@@ -65,11 +65,6 @@ export default class Divicon extends MapLayer {
     }
   }
 
-  componentWillMount() {
-    super.componentWillMount();
-    this.leafletElement = this.createLeafletElement(this.props);
-  }
-
   componentDidMount() {
     super.componentDidMount();
     this.renderComponent();
@@ -99,6 +94,6 @@ export default class Divicon extends MapLayer {
   render() {
     return null;
   }
-
 }
 
+export default withLeaflet(Divicon)

--- a/index.js
+++ b/index.js
@@ -7,8 +7,6 @@ exports.Divicon = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
-
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _react = require('react');
@@ -16,6 +14,8 @@ var _react = require('react');
 var _react2 = _interopRequireDefault(_react);
 
 var _reactDom = require('react-dom');
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
 
 var _leaflet = require('leaflet');
 
@@ -35,78 +35,20 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-function createContextProvider(context) {
-  var ContextProvider = function (_Component) {
-    _inherits(ContextProvider, _Component);
-
-    function ContextProvider() {
-      _classCallCheck(this, ContextProvider);
-
-      return _possibleConstructorReturn(this, (ContextProvider.__proto__ || Object.getPrototypeOf(ContextProvider)).apply(this, arguments));
-    }
-
-    _createClass(ContextProvider, [{
-      key: 'getChildContext',
-      value: function getChildContext() {
-        return context;
-      }
-    }, {
-      key: 'render',
-      value: function render() {
-        return this.props.children;
-      }
-    }]);
-
-    return ContextProvider;
-  }(_react.Component);
-
-  ContextProvider.childContextTypes = {};
-  Object.keys(context).forEach(function (key) {
-    ContextProvider.childContextTypes[key] = _propTypes2.default.any;
-  });
-  return ContextProvider;
-}
-
 var Divicon = exports.Divicon = function (_MapLayer) {
   _inherits(Divicon, _MapLayer);
 
   function Divicon() {
-    var _ref;
-
-    var _temp, _this2, _ret;
-
     _classCallCheck(this, Divicon);
 
-    for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-      args[_key] = arguments[_key];
-    }
-
-    return _ret = (_temp = (_this2 = _possibleConstructorReturn(this, (_ref = Divicon.__proto__ || Object.getPrototypeOf(Divicon)).call.apply(_ref, [this].concat(args))), _this2), _this2.renderComponent = function () {
-      var ContextProvider = createContextProvider(_extends({}, _this2.context, _this2.getChildContext()));
-      var container = _this2.leafletElement._icon;
-      var component = _react2.default.createElement(
-        ContextProvider,
-        null,
-        _this2.props.children
-      );
-      if (container) {
-        (0, _reactDom.render)(component, container);
-      }
-    }, _temp), _possibleConstructorReturn(_this2, _ret);
+    return _possibleConstructorReturn(this, (Divicon.__proto__ || Object.getPrototypeOf(Divicon)).apply(this, arguments));
   }
 
   _createClass(Divicon, [{
-    key: 'getChildContext',
-    value: function getChildContext() {
-      return {
-        popupContainer: this.leafletElement
-      };
-    }
+    key: 'createLeafletElement',
+
 
     // See https://github.com/PaulLeCam/react-leaflet/issues/275
-
-  }, {
-    key: 'createLeafletElement',
     value: function createLeafletElement(newProps) {
       var _map = newProps.map,
           _lc = newProps.layerContainer,
@@ -137,21 +79,20 @@ var Divicon = exports.Divicon = function (_MapLayer) {
       }
     }
   }, {
-    key: 'componentDidMount',
-    value: function componentDidMount() {
-      _get(Divicon.prototype.__proto__ || Object.getPrototypeOf(Divicon.prototype), 'componentDidMount', this).call(this);
-      this.renderComponent();
-    }
-  }, {
     key: 'componentDidUpdate',
     value: function componentDidUpdate(fromProps) {
-      this.renderComponent();
       this.updateLeafletElement(fromProps, this.props);
     }
   }, {
     key: 'render',
     value: function render() {
-      return null;
+      var container = this.leafletElement._icon;
+
+      if (container) {
+        return _reactDom2.default.createPortal(this.props.children, container);
+      } else {
+        return null;
+      }
     }
   }]);
 
@@ -160,10 +101,6 @@ var Divicon = exports.Divicon = function (_MapLayer) {
 
 Divicon.propTypes = {
   opacity: _propTypes2.default.number,
-  zIndexOffset: _propTypes2.default.number
-};
-Divicon.childContextTypes = {
-  popupContainer: _propTypes2.default.object
-};
+  zIndexOffset: _propTypes2.default.number };
 exports.default = (0, _reactLeaflet.withLeaflet)(Divicon);
 

--- a/index.js
+++ b/index.js
@@ -136,12 +136,6 @@ var Divicon = function (_MapLayer) {
       }
     }
   }, {
-    key: 'componentWillMount',
-    value: function componentWillMount() {
-      _get(Divicon.prototype.__proto__ || Object.getPrototypeOf(Divicon.prototype), 'componentWillMount', this).call(this);
-      this.leafletElement = this.createLeafletElement(this.props);
-    }
-  }, {
     key: 'componentDidMount',
     value: function componentDidMount() {
       _get(Divicon.prototype.__proto__ || Object.getPrototypeOf(Divicon.prototype), 'componentDidMount', this).call(this);
@@ -170,5 +164,5 @@ Divicon.propTypes = {
 Divicon.childContextTypes = {
   popupContainer: _propTypes2.default.object
 };
-exports.default = Divicon;
+exports.default = (0, _reactLeaflet.withLeaflet)(Divicon);
 

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
+var _get = function get(object, property, receiver) { if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { return get(parent, property, receiver); } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } };
+
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -38,17 +40,20 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 var Divicon = exports.Divicon = function (_MapLayer) {
   _inherits(Divicon, _MapLayer);
 
-  function Divicon() {
+  function Divicon(props) {
     _classCallCheck(this, Divicon);
 
-    return _possibleConstructorReturn(this, (Divicon.__proto__ || Object.getPrototypeOf(Divicon)).apply(this, arguments));
+    var _this = _possibleConstructorReturn(this, (Divicon.__proto__ || Object.getPrototypeOf(Divicon)).call(this, props));
+
+    _get(Divicon.prototype.__proto__ || Object.getPrototypeOf(Divicon.prototype), 'componentDidMount', _this).call(_this);
+    return _this;
   }
+
+  // See https://github.com/PaulLeCam/react-leaflet/issues/275
+
 
   _createClass(Divicon, [{
     key: 'createLeafletElement',
-
-
-    // See https://github.com/PaulLeCam/react-leaflet/issues/275
     value: function createLeafletElement(newProps) {
       var _map = newProps.map,
           _lc = newProps.layerContainer,
@@ -56,7 +61,9 @@ var Divicon = exports.Divicon = function (_MapLayer) {
           props = _objectWithoutProperties(newProps, ['map', 'layerContainer', 'position']);
 
       this.icon = new _leaflet.DivIcon(props);
-      return (0, _leaflet.marker)(position, _extends({ icon: this.icon }, props));
+      var m = (0, _leaflet.marker)(position, _extends({ icon: this.icon }, props));
+      this.contextValue = _extends({}, props.leaflet, { popupContainer: m });
+      return m;
     }
   }, {
     key: 'updateLeafletElement',
@@ -87,9 +94,12 @@ var Divicon = exports.Divicon = function (_MapLayer) {
     key: 'render',
     value: function render() {
       var container = this.leafletElement._icon;
-
       if (container) {
-        return _reactDom2.default.createPortal(this.props.children, container);
+        return _reactDom2.default.createPortal(_react2.default.createElement(
+          _reactLeaflet.LeafletProvider,
+          { value: this.contextValue },
+          this.props.children
+        ), container);
       } else {
         return null;
       }
@@ -101,6 +111,7 @@ var Divicon = exports.Divicon = function (_MapLayer) {
 
 Divicon.propTypes = {
   opacity: _propTypes2.default.number,
-  zIndexOffset: _propTypes2.default.number };
+  zIndexOffset: _propTypes2.default.number
+};
 exports.default = (0, _reactLeaflet.withLeaflet)(Divicon);
 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.Divicon = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
@@ -66,7 +67,7 @@ function createContextProvider(context) {
   return ContextProvider;
 }
 
-var Divicon = function (_MapLayer) {
+var Divicon = exports.Divicon = function (_MapLayer) {
   _inherits(Divicon, _MapLayer);
 
   function Divicon() {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-preset-stage-0": "^6.5.0"
   },
   "peerDependencies": {
-    "leaflet": "^0.7.0",
+    "leaflet": "^1.3.0",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
     "react-leaflet": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "leaflet": "^0.7.0",
     "react": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
     "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0-rc",
-    "react-leaflet": "^0.11.5"
+    "react-leaflet": "^2.0.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10"


### PR DESCRIPTION
Calling `createLeafletElement` from the `componentWillMount` method is not necessary anymore. The constructor of the `MapLayer` component already does that.

The `Divicon` component is now also wrapped with the `withLeaflet()` higher-order component to provide the right context.
https://react-leaflet.js.org/docs/en/custom-components.html#docsNav

I still exported both the wrapped and unwrapped component. In my use case, this helps me to provide the redux store to the components inside the `Divicon`.
Let me know if you have a better idea of how to solve this. 